### PR TITLE
Adding CT Exclusions to `.rmd` outputs

### DIFF
--- a/src/model/y1/y1_3_ct.R
+++ b/src/model/y1/y1_3_ct.R
@@ -15,3 +15,7 @@ y1_ct_output = y1_ct_list[[6]]
 
 y1_ct_opt_out <- y1_ct_list[[7]] %>%
   select(1:3) 
+
+# Creating ct exclusions output
+
+y1_ct_ex <- y1_ct_list[[1]]

--- a/src/model/y2/y2_3_ct.R
+++ b/src/model/y2/y2_3_ct.R
@@ -15,3 +15,7 @@ y2_ct_output = y2_ct_list[[6]]
 
 y2_ct_opt_out <- y2_ct_list[[7]] %>%
   select(1:3) 
+
+# Creating ct exclusions output
+
+y2_ct_ex <- y2_ct_list[[1]]

--- a/src/model/y3/y3_3_ct.R
+++ b/src/model/y3/y3_3_ct.R
@@ -15,3 +15,7 @@ y3_ct_output = y3_ct_list[[6]]
 
 y3_ct_opt_out <- y3_ct_list[[7]] %>%
   select(1:3) 
+
+# Creating ct exclusions output
+
+y3_ct_ex <- y3_ct_list[[1]]

--- a/src/model/y4/y4_3_ct.R
+++ b/src/model/y4/y4_3_ct.R
@@ -15,3 +15,7 @@ y4_ct_output = y4_ct_list[[6]]
 
 y4_ct_opt_out <- y4_ct_list[[7]] %>%
   select(1:3) 
+
+# Creating ct exclusions output
+
+y4_ct_ex <- y4_ct_list[[1]]

--- a/src/model/y5/y5_3_ct.R
+++ b/src/model/y5/y5_3_ct.R
@@ -15,3 +15,7 @@ y5_ct_output = y5_ct_list[[6]]
 
 y5_ct_opt_out <- y5_ct_list[[7]] %>%
   select(1:3) 
+
+# Creating ct exclusions output
+
+y5_ct_ex <- y5_ct_list[[1]]

--- a/src/outputs/lhc_model_output.Rmd
+++ b/src/outputs/lhc_model_output.Rmd
@@ -464,6 +464,29 @@ y1_ct_opt_out_hist
 
 <br/>
 
+#### CT Scan Exclusions
+The table below shows a summary of the number of patients who were excluded from receiving a CT scan across the `r trials` model runs:
+
+```{r y1_ct_ex_table}
+
+y1_ct_ex_tab
+
+```
+
+
+<br/>
+
+The distribution of exclusions across these model runs is shown in the histogram below:
+
+```{r y1_ct_ex_hist, out.width='100%'}
+
+y1_ct_ex_chart
+
+```
+
+<br/>
+
+
 ### Initial Treatments {.tabset .tabset-fade}
 For patients who have a concerning CT scan they will fall within one of three groups. Those requiring further diagnostics, those with an incidental finding and those who will be referred for a three month follow-up scan. For those patients who undergo further diagnostics these will confirm if there is a malignancy requiring treatment. These patients will receive one of eight potential treatment modalities. This is based on the probabilities applied to the model. This section provides an overview of:
 
@@ -1156,6 +1179,28 @@ The distribution of opt-outs across these model runs is shown in the histogram b
 ```{r y2_ct_opt_out_hist, out.width='100%'}
 
 y2_ct_opt_out_hist
+
+```
+
+<br/>
+
+#### CT Scan Exclusions
+The table below shows a summary of the number of patients who were excluded from receiving a CT scan across the `r trials` model runs:
+
+```{r y2_ct_ex_table}
+
+y2_ct_ex_tab
+
+```
+
+
+<br/>
+
+The distribution of exclusions across these model runs is shown in the histogram below:
+
+```{r y2_ct_ex_hist, out.width='100%'}
+
+y2_ct_ex_chart
 
 ```
 
@@ -1858,6 +1903,28 @@ y3_ct_opt_out_hist
 
 <br/>
 
+#### CT Scan Exclusions
+The table below shows a summary of the number of patients who were excluded from receiving a CT scan across the `r trials` model runs:
+
+```{r y3_ct_ex_table}
+
+y3_ct_ex_tab
+
+```
+
+
+<br/>
+
+The distribution of exclusions across these model runs is shown in the histogram below:
+
+```{r y3_ct_ex_hist, out.width='100%'}
+
+y3_ct_ex_chart
+
+```
+
+<br/>
+
 ### Initial Treatments {.tabset .tabset-fade}
 For patients who have a concerning CT scan they will fall within one of three groups. Those requiring further diagnostics, those with an incidental finding and those who will be referred for a three month follow-up scan. For those patients who undergo further diagnostics these will confirm if there is a malignancy requiring treatment. These patients will receive one of eight potential treatment modalities. This is based on the probabilities applied to the model. This section provides an overview of:
 
@@ -2553,6 +2620,29 @@ y4_ct_opt_out_hist
 
 <br/>
 
+#### CT Scan Exclusions
+The table below shows a summary of the number of patients who were excluded from receiving a CT scan across the `r trials` model runs:
+
+```{r y4_ct_ex_table}
+
+y4_ct_ex_tab
+
+```
+
+
+<br/>
+
+The distribution of exclusions across these model runs is shown in the histogram below:
+
+```{r y4_ct_ex_hist, out.width='100%'}
+
+y4_ct_ex_chart
+
+```
+
+<br/>
+
+
 ### Initial Treatments {.tabset .tabset-fade}
 For patients who have a concerning CT scan they will fall within one of three groups. Those requiring further diagnostics, those with an incidental finding and those who will be referred for a three month follow-up scan. For those patients who undergo further diagnostics these will confirm if there is a malignancy requiring treatment. These patients will receive one of eight potential treatment modalities. This is based on the probabilities applied to the model. This section provides an overview of:
 
@@ -3247,6 +3337,29 @@ y5_ct_opt_out_hist
 ```
 
 <br/>
+
+#### CT Scan Exclusions
+The table below shows a summary of the number of patients who were excluded from receiving a CT scan across the `r trials` model runs:
+
+```{r y5_ct_ex_table}
+
+y5_ct_ex_tab
+
+```
+
+
+<br/>
+
+The distribution of exclusions across these model runs is shown in the histogram below:
+
+```{r y5_ct_ex_hist, out.width='100%'}
+
+y5_ct_ex_chart
+
+```
+
+<br/>
+
 
 ### Initial Treatments {.tabset .tabset-fade}
 For patients who have a concerning CT scan they will fall within one of three groups. Those requiring further diagnostics, those with an incidental finding and those who will be referred for a three month follow-up scan. For those patients who undergo further diagnostics these will confirm if there is a malignancy requiring treatment. These patients will receive one of eight potential treatment modalities. This is based on the probabilities applied to the model. This section provides an overview of:

--- a/src/visualisation/functions/ct.R
+++ b/src/visualisation/functions/ct.R
@@ -107,7 +107,7 @@ ct_ex_chart_visual <- function(input_df, fill_hex, sub_label){
     geom_histogram(fill = fill_hex, alpha = 0.5, color = "#000000", bins = 20) +
     labs(x = "Number of patients",
          y = "Number of Trials",
-         title = "Histogram of in year patients opting out at CT scan",
+         title = "Histogram of in year CT scan exclusions",
          subtitle = sub_label,
          caption = "Model Output") +
     theme_tu_white(hex_col = "#407EC9")

--- a/src/visualisation/functions/ct.R
+++ b/src/visualisation/functions/ct.R
@@ -97,3 +97,20 @@ ct_opt_out_chart_visual <- function(input_df, fill_hex, sub_label){
     theme_tu_white(hex_col = "#407EC9")
   
 }
+
+
+# CT Exclusions -----------------------------------------------------------
+
+ct_ex_chart_visual <- function(input_df, fill_hex, sub_label){
+  
+  ct_ex_chart <- ggplot(input_df, aes(x = Total)) +
+    geom_histogram(fill = fill_hex, alpha = 0.5, color = "#000000", bins = 20) +
+    labs(x = "Number of patients",
+         y = "Number of Trials",
+         title = "Histogram of in year patients opting out at CT scan",
+         subtitle = sub_label,
+         caption = "Model Output") +
+    theme_tu_white(hex_col = "#407EC9")
+  
+}
+

--- a/src/visualisation/tables/y1_tables.R
+++ b/src/visualisation/tables/y1_tables.R
@@ -316,6 +316,27 @@ y1_ct_opt_out_tab_vis <- y1_ct_opt_out_tab_formatted %>%
   row_spec(0, background = "#407EC9", color = "white")
 
 
+
+# ct exclusions -----------------------------------------------------------
+
+y1_ct_ex_tab <- y1_ct_ex %>%
+  summarize(
+    percentile_10 = round(quantile(Total, probs = 0.1, na.rm = TRUE), 0),
+    lower_quartile = round(quantile(Total, probs = 0.25, na.rm = TRUE), 0),
+    median = round(median(Total, na.rm = TRUE), 0),
+    upper_quartile = round(quantile(Total, probs = 0.75, na.rm = TRUE), 0),
+    percentile_90 = round(quantile(Total, probs = 0.9, na.rm = TRUE), 0)
+  ) %>%
+  rename("10th Percentile" = 1,
+         "Lower Quartile" = 2,
+         "Median" = 3,
+         "Upper Quartile" = 4,
+         "90th Percentile" = 5) %>%
+  kable(format = "html", align = "lrrrrr") %>%
+  kable_styling() %>%
+  row_spec(0, background = "#407EC9", color = "white")
+
+
 # init scan outcomes table ------------------------------------------------
 
 y1_ct_init_scan_tab <- y1_init_treat_groups_list[[1]] %>%

--- a/src/visualisation/tables/y2_tables.R
+++ b/src/visualisation/tables/y2_tables.R
@@ -316,6 +316,25 @@ y2_ct_opt_out_tab_vis <- y2_ct_opt_out_tab_formatted %>%
   row_spec(0, background = "#407EC9", color = "white")
 
 
+# ct exclusions -----------------------------------------------------------
+
+y2_ct_ex_tab <- y2_ct_ex %>%
+  summarize(
+    percentile_10 = round(quantile(Total, probs = 0.1, na.rm = TRUE), 0),
+    lower_quartile = round(quantile(Total, probs = 0.25, na.rm = TRUE), 0),
+    median = round(median(Total, na.rm = TRUE), 0),
+    upper_quartile = round(quantile(Total, probs = 0.75, na.rm = TRUE), 0),
+    percentile_90 = round(quantile(Total, probs = 0.9, na.rm = TRUE), 0)
+  ) %>%
+  rename("10th Percentile" = 1,
+         "Lower Quartile" = 2,
+         "Median" = 3,
+         "Upper Quartile" = 4,
+         "90th Percentile" = 5) %>%
+  kable(format = "html", align = "lrrrrr") %>%
+  kable_styling() %>%
+  row_spec(0, background = "#407EC9", color = "white")
+
 # init scan outcomes table ------------------------------------------------
 
 y2_ct_init_scan_tab <- y2_init_treat_groups_list[[1]] %>%

--- a/src/visualisation/tables/y3_tables.R
+++ b/src/visualisation/tables/y3_tables.R
@@ -316,6 +316,25 @@ y3_ct_opt_out_tab_vis <- y3_ct_opt_out_tab_formatted %>%
   row_spec(0, background = "#407EC9", color = "white")
 
 
+# ct exclusions -----------------------------------------------------------
+
+y3_ct_ex_tab <- y3_ct_ex %>%
+  summarize(
+    percentile_10 = round(quantile(Total, probs = 0.1, na.rm = TRUE), 0),
+    lower_quartile = round(quantile(Total, probs = 0.25, na.rm = TRUE), 0),
+    median = round(median(Total, na.rm = TRUE), 0),
+    upper_quartile = round(quantile(Total, probs = 0.75, na.rm = TRUE), 0),
+    percentile_90 = round(quantile(Total, probs = 0.9, na.rm = TRUE), 0)
+  ) %>%
+  rename("10th Percentile" = 1,
+         "Lower Quartile" = 2,
+         "Median" = 3,
+         "Upper Quartile" = 4,
+         "90th Percentile" = 5) %>%
+  kable(format = "html", align = "lrrrrr") %>%
+  kable_styling() %>%
+  row_spec(0, background = "#407EC9", color = "white")
+
 # init scan outcomes table ------------------------------------------------
 
 y3_ct_init_scan_tab <- y3_init_treat_groups_list[[1]] %>%

--- a/src/visualisation/tables/y4_tables.R
+++ b/src/visualisation/tables/y4_tables.R
@@ -316,6 +316,26 @@ y4_ct_opt_out_tab_vis <- y4_ct_opt_out_tab_formatted %>%
   row_spec(0, background = "#407EC9", color = "white")
 
 
+# ct exclusions -----------------------------------------------------------
+
+y4_ct_ex_tab <- y4_ct_ex %>%
+  summarize(
+    percentile_10 = round(quantile(Total, probs = 0.1, na.rm = TRUE), 0),
+    lower_quartile = round(quantile(Total, probs = 0.25, na.rm = TRUE), 0),
+    median = round(median(Total, na.rm = TRUE), 0),
+    upper_quartile = round(quantile(Total, probs = 0.75, na.rm = TRUE), 0),
+    percentile_90 = round(quantile(Total, probs = 0.9, na.rm = TRUE), 0)
+  ) %>%
+  rename("10th Percentile" = 1,
+         "Lower Quartile" = 2,
+         "Median" = 3,
+         "Upper Quartile" = 4,
+         "90th Percentile" = 5) %>%
+  kable(format = "html", align = "lrrrrr") %>%
+  kable_styling() %>%
+  row_spec(0, background = "#407EC9", color = "white")
+
+
 # init scan outcomes table ------------------------------------------------
 
 y4_ct_init_scan_tab <- y4_init_treat_groups_list[[1]] %>%

--- a/src/visualisation/tables/y5_tables.R
+++ b/src/visualisation/tables/y5_tables.R
@@ -316,6 +316,26 @@ y5_ct_opt_out_tab_vis <- y5_ct_opt_out_tab_formatted %>%
   row_spec(0, background = "#407EC9", color = "white")
 
 
+# ct exclusion ------------------------------------------------------------
+
+y5_ct_ex_tab <- y5_ct_ex %>%
+  summarize(
+    percentile_10 = round(quantile(Total, probs = 0.1, na.rm = TRUE), 0),
+    lower_quartile = round(quantile(Total, probs = 0.25, na.rm = TRUE), 0),
+    median = round(median(Total, na.rm = TRUE), 0),
+    upper_quartile = round(quantile(Total, probs = 0.75, na.rm = TRUE), 0),
+    percentile_90 = round(quantile(Total, probs = 0.9, na.rm = TRUE), 0)
+  ) %>%
+  rename("10th Percentile" = 1,
+         "Lower Quartile" = 2,
+         "Median" = 3,
+         "Upper Quartile" = 4,
+         "90th Percentile" = 5) %>%
+  kable(format = "html", align = "lrrrrr") %>%
+  kable_styling() %>%
+  row_spec(0, background = "#407EC9", color = "white")
+
+
 # init scan outcomes table ------------------------------------------------
 
 y5_ct_init_scan_tab <- y5_init_treat_groups_list[[1]] %>%

--- a/src/visualisation/y1_visuals.R
+++ b/src/visualisation/y1_visuals.R
@@ -65,6 +65,10 @@ y1_ct_opt_out_hist_df <- y1_ct_list[[7]] %>%
 y1_ct_opt_out_hist <- ct_opt_out_chart_visual(y1_ct_opt_out_hist_df, "#407EC9", "Year 1")
 
 
+# CT Exclusions -----------------------------------------------------------
+
+y1_ct_ex_chart <- ct_ex_chart_visual(y1_ct_ex, "#407EC9", "Year 1")
+
 # Initial Treatment Positive CT Outcomes ----------------------------------
 
 y1_init_treat_pos_outcomes_hist_df <- y1_init_treat_groups_list[[1]] %>%

--- a/src/visualisation/y2_visuals.R
+++ b/src/visualisation/y2_visuals.R
@@ -64,6 +64,11 @@ y2_ct_opt_out_hist_df <- y2_ct_list[[7]] %>%
 
 y2_ct_opt_out_hist <- ct_opt_out_chart_visual(y2_ct_opt_out_hist_df, "#407EC9", "Year 2")
 
+
+# CT Exclusions -----------------------------------------------------------
+
+y2_ct_ex_chart <- ct_ex_chart_visual(y2_ct_ex, "#407EC9", "Year 2")
+
 # Initial Treatment Positive CT Outcomes ----------------------------------
 
 y2_init_treat_pos_outcomes_hist_df <- y2_init_treat_groups_list[[1]] %>%

--- a/src/visualisation/y3_visuals.R
+++ b/src/visualisation/y3_visuals.R
@@ -64,6 +64,11 @@ y3_ct_opt_out_hist_df <- y3_ct_list[[7]] %>%
 
 y3_ct_opt_out_hist <- ct_opt_out_chart_visual(y3_ct_opt_out_hist_df, "#407EC9", "Year 3")
 
+
+# CT Exclusions -----------------------------------------------------------
+
+y3_ct_ex_chart <- ct_ex_chart_visual(y3_ct_ex, "#407EC9", "Year 3")
+
 # Initial Treatment Positive CT Outcomes ----------------------------------
 
 y3_init_treat_pos_outcomes_hist_df <- y3_init_treat_groups_list[[1]] %>%

--- a/src/visualisation/y4_visuals.R
+++ b/src/visualisation/y4_visuals.R
@@ -47,6 +47,10 @@ y4_ct_outcomes_hist_df <- y4_ct_list[[3]]
 y4_ct_outcomes_hist <- ct_outcomes_chart_visual(y4_ct_outcomes_hist_df, "#407EC9", "Year 4")
 
 
+# CT Exclusions -----------------------------------------------------------
+
+y4_ct_ex_chart <- ct_ex_chart_visual(y4_ct_ex, "#407EC9", "Year 4")
+
 # CT Scan Negative Follow-ups ---------------------------------------------
 
 y4_ct_neg_ri_hist_df <- y4_ct_list[[5]] %>%

--- a/src/visualisation/y5_visuals.R
+++ b/src/visualisation/y5_visuals.R
@@ -64,6 +64,11 @@ y5_ct_opt_out_hist_df <- y5_ct_list[[7]] %>%
 
 y5_ct_opt_out_hist <- ct_opt_out_chart_visual(y5_ct_opt_out_hist_df, "#407EC9", "Year 5")
 
+
+# CT Exclusions -----------------------------------------------------------
+
+y5_ct_ex_chart <- ct_ex_chart_visual(y5_ct_ex, "#407EC9", "Year 5")
+
 # Initial Treatment Positive CT Outcomes ----------------------------------
 
 y5_init_treat_pos_outcomes_hist_df <- y5_init_treat_groups_list[[1]] %>%


### PR DESCRIPTION
This PR is to add the summary tables and histogram showing the number of patients being excluded from the initial CT each year of the model.

This PR is related to #26