### PR TITLE
Add Nodule Follow-Ups to outputs

### DIFF
--- a/src/config/assumptions/assumptions_treatments_m12.R
+++ b/src/config/assumptions/assumptions_treatments_m12.R
@@ -29,11 +29,17 @@ m12_incidental_rate_y3 <- assumptions_m12_treat[[4,6]]
 m12_incidental_rate_y4 <- assumptions_m12_treat[[4,7]]
 m12_incidental_rate_y5 <- assumptions_m12_treat[[4,8]]
 
-m12_m24_fu_rate_y1 <- 1 - m12_diagnostic_rate_y1 - m12_incidental_rate_y1
-m12_m24_fu_rate_y2 <- 1 - m12_diagnostic_rate_y2 - m12_incidental_rate_y2
-m12_m24_fu_rate_y3 <- 1 - m12_diagnostic_rate_y3 - m12_incidental_rate_y3
-m12_m24_fu_rate_y4 <- 1 - m12_diagnostic_rate_y4 - m12_incidental_rate_y4
-m12_m24_fu_rate_y5 <- 1 - m12_diagnostic_rate_y5 - m12_incidental_rate_y5
+m12_nodule_rate_y1 <- assumptions_m12_treat[[5,4]]
+m12_nodule_rate_y2 <- assumptions_m12_treat[[5,5]]
+m12_nodule_rate_y3 <- assumptions_m12_treat[[5,6]]
+m12_nodule_rate_y4 <- assumptions_m12_treat[[5,7]]
+m12_nodule_rate_y5 <- assumptions_m12_treat[[5,8]]
+
+m12_m24_fu_rate_y1 <- 1 - m12_diagnostic_rate_y1 - m12_incidental_rate_y1 - m12_nodule_rate_y1
+m12_m24_fu_rate_y2 <- 1 - m12_diagnostic_rate_y2 - m12_incidental_rate_y2 - m12_nodule_rate_y2
+m12_m24_fu_rate_y3 <- 1 - m12_diagnostic_rate_y3 - m12_incidental_rate_y3 - m12_nodule_rate_y3
+m12_m24_fu_rate_y4 <- 1 - m12_diagnostic_rate_y4 - m12_incidental_rate_y4 - m12_nodule_rate_y4
+m12_m24_fu_rate_y5 <- 1 - m12_diagnostic_rate_y5 - m12_incidental_rate_y5 - m12_nodule_rate_y5
 
 m12_cancer_rate_y1 <- assumptions_m12_treat[[6,4]]
 m12_cancer_rate_y2 <- assumptions_m12_treat[[6,5]]

--- a/src/config/assumptions/assumptions_treatments_m24.R
+++ b/src/config/assumptions/assumptions_treatments_m24.R
@@ -29,11 +29,17 @@ m24_incidental_rate_y3 <- assumptions_m24_treat[[4,6]]
 m24_incidental_rate_y4 <- assumptions_m24_treat[[4,7]]
 m24_incidental_rate_y5 <- assumptions_m24_treat[[4,8]]
 
-m24_m24_fu_rate_y1 <- 1 - m24_diagnostic_rate_y1 - m24_incidental_rate_y1
-m24_m24_fu_rate_y2 <- 1 - m24_diagnostic_rate_y2 - m24_incidental_rate_y2
-m24_m24_fu_rate_y3 <- 1 - m24_diagnostic_rate_y3 - m24_incidental_rate_y3
-m24_m24_fu_rate_y4 <- 1 - m24_diagnostic_rate_y4 - m24_incidental_rate_y4
-m24_m24_fu_rate_y5 <- 1 - m24_diagnostic_rate_y5 - m24_incidental_rate_y5
+m24_nodule_rate_y1 <- assumptions_m24_treat[[5,4]]
+m24_nodule_rate_y2 <- assumptions_m24_treat[[5,5]]
+m24_nodule_rate_y3 <- assumptions_m24_treat[[5,6]]
+m24_nodule_rate_y4 <- assumptions_m24_treat[[5,7]]
+m24_nodule_rate_y5 <- assumptions_m24_treat[[5,8]]
+
+m24_m24_fu_rate_y1 <- 1 - m24_diagnostic_rate_y1 - m24_incidental_rate_y1 - m24_nodule_rate_y1
+m24_m24_fu_rate_y2 <- 1 - m24_diagnostic_rate_y2 - m24_incidental_rate_y2 - m24_nodule_rate_y2
+m24_m24_fu_rate_y3 <- 1 - m24_diagnostic_rate_y3 - m24_incidental_rate_y3 - m24_nodule_rate_y3
+m24_m24_fu_rate_y4 <- 1 - m24_diagnostic_rate_y4 - m24_incidental_rate_y4 - m24_nodule_rate_y4
+m24_m24_fu_rate_y5 <- 1 - m24_diagnostic_rate_y5 - m24_incidental_rate_y5 - m24_nodule_rate_y5
 
 m24_cancer_rate_y1 <- assumptions_m24_treat[[6,4]]
 m24_cancer_rate_y2 <- assumptions_m24_treat[[6,5]]

--- a/src/model/functions/m12_treatment.R
+++ b/src/model/functions/m12_treatment.R
@@ -1,4 +1,4 @@
-m12_treat_groups <- function(input_df, dna_rate, rebook_rate, diagnostic_rate, incidental_rate, follow_up_rate, 
+m12_treat_groups <- function(input_df, dna_rate, rebook_rate, diagnostic_rate, incidental_rate, nodule_rate, follow_up_rate, 
                                  cancer_rate){
   
   ### Simulate DNA and Rebooking for non-excluded patients
@@ -25,6 +25,7 @@ m12_treat_groups <- function(input_df, dna_rate, rebook_rate, diagnostic_rate, i
     mutate(m12_treat_outcome_prob = runif(n()),
            m12_treat_outcome = case_when(m12_treat_outcome_prob < diagnostic_rate ~ "Diagnostics",
                                          m12_treat_outcome_prob < diagnostic_rate + incidental_rate ~ "Incidental",
+                                         m12_treat_outcome_prob < diagnostic_rate + incidental_rate + nodule_rate ~ "Nodule FU",
                                           TRUE ~ "24M_FU"))
   
   ### Aggregate m12 outcomes

--- a/src/model/functions/m24_treatment.R
+++ b/src/model/functions/m24_treatment.R
@@ -1,4 +1,4 @@
-m24_treat_groups <- function(input_df, dna_rate, rebook_rate, diagnostic_rate, incidental_rate, follow_up_rate, 
+m24_treat_groups <- function(input_df, dna_rate, rebook_rate, diagnostic_rate, incidental_rate, nodule_rate, follow_up_rate, 
                                  cancer_rate){
   
   ### Simulate DNA and Rebooking for non-excluded patients
@@ -25,6 +25,7 @@ m24_treat_groups <- function(input_df, dna_rate, rebook_rate, diagnostic_rate, i
     mutate(m24_treat_outcome_prob = runif(n()),
            m24_treat_outcome = case_when(m24_treat_outcome_prob < diagnostic_rate ~ "Diagnostics",
                                          m24_treat_outcome_prob < diagnostic_rate + incidental_rate ~ "Incidental",
+                                         m24_treat_outcome_prob < diagnostic_rate + incidental_rate + nodule_rate ~ "Nodule FU",
                                           TRUE ~ "48M_FU"))
   
   ### Aggregate m24 outcomes

--- a/src/model/y1/y1_10_m24_treat.R
+++ b/src/model/y1/y1_10_m24_treat.R
@@ -6,6 +6,7 @@ y1_m24_treat_groups_list <- m24_treat_groups(input_df = y1_m24_FU_input_df,
                                              rebook_rate= m24_scan_rebook_rate_y1,
                                              diagnostic_rate = m24_diagnostic_rate_y1,
                                              incidental_rate = m24_incidental_rate_y1,
+                                             nodule_rate = m24_nodule_rate_y1,
                                              follow_up_rate = m24_m24_fu_rate_y1,
                                              cancer_rate = m24_cancer_rate_y1)
 

--- a/src/model/y1/y1_8_m12_treat.R
+++ b/src/model/y1/y1_8_m12_treat.R
@@ -6,6 +6,7 @@ y1_m12_treat_groups_list <- m12_treat_groups(input_df = y1_m12_FU_input_df,
                                              rebook_rate= m12_scan_rebook_rate_y1,
                                              diagnostic_rate = m12_diagnostic_rate_y1,
                                              incidental_rate = m12_incidental_rate_y1,
+                                             nodule_rate = m12_nodule_rate_y1,
                                              follow_up_rate = m12_m24_fu_rate_y1,
                                              cancer_rate = m12_cancer_rate_y1)
 

--- a/src/model/y2/y2_10_m24_treat.R
+++ b/src/model/y2/y2_10_m24_treat.R
@@ -6,6 +6,7 @@ y2_m24_treat_groups_list <- m24_treat_groups(input_df = y2_m24_FU_input_df,
                                              rebook_rate= m24_scan_rebook_rate_y2,
                                              diagnostic_rate = m24_diagnostic_rate_y2,
                                              incidental_rate = m24_incidental_rate_y2,
+                                             nodule_rate = m24_nodule_rate_y2,
                                              follow_up_rate = m24_m24_fu_rate_y2,
                                              cancer_rate = m24_cancer_rate_y2)
 

--- a/src/model/y2/y2_8_m12_treat.R
+++ b/src/model/y2/y2_8_m12_treat.R
@@ -6,6 +6,7 @@ y2_m12_treat_groups_list <- m12_treat_groups(input_df = y2_m12_FU_input_df,
                                              rebook_rate= m12_scan_rebook_rate_y2,
                                              diagnostic_rate = m12_diagnostic_rate_y2,
                                              incidental_rate = m12_incidental_rate_y2,
+                                             nodule_rate = m12_nodule_rate_y2,
                                              follow_up_rate = m12_m12_fu_rate_y2,
                                              cancer_rate = m12_cancer_rate_y2)
 

--- a/src/model/y3/y3_10_m24_treat.R
+++ b/src/model/y3/y3_10_m24_treat.R
@@ -6,6 +6,7 @@ y3_m24_treat_groups_list <- m24_treat_groups(input_df = y3_m24_FU_input_df,
                                              rebook_rate= m24_scan_rebook_rate_y3,
                                              diagnostic_rate = m24_diagnostic_rate_y3,
                                              incidental_rate = m24_incidental_rate_y3,
+                                             nodule_rate = m24_nodule_rate_y3,
                                              follow_up_rate = m24_m24_fu_rate_y3,
                                              cancer_rate = m24_cancer_rate_y3)
 

--- a/src/model/y3/y3_8_m12_treat.R
+++ b/src/model/y3/y3_8_m12_treat.R
@@ -6,6 +6,7 @@ y3_m12_treat_groups_list <- m12_treat_groups(input_df = y3_m12_FU_input_df,
                                              rebook_rate= m12_scan_rebook_rate_y3,
                                              diagnostic_rate = m12_diagnostic_rate_y3,
                                              incidental_rate = m12_incidental_rate_y3,
+                                             nodule_rate = m12_nodule_rate_y3,
                                              follow_up_rate = m12_m12_fu_rate_y3,
                                              cancer_rate = m12_cancer_rate_y3)
 

--- a/src/model/y4/y4_10_m24_treat.R
+++ b/src/model/y4/y4_10_m24_treat.R
@@ -6,6 +6,7 @@ y4_m24_treat_groups_list <- m24_treat_groups(input_df = y4_m24_FU_input_df,
                                              rebook_rate= m24_scan_rebook_rate_y4,
                                              diagnostic_rate = m24_diagnostic_rate_y4,
                                              incidental_rate = m24_incidental_rate_y4,
+                                             nodule_rate = m24_nodule_rate_y4,
                                              follow_up_rate = m24_m24_fu_rate_y4,
                                              cancer_rate = m24_cancer_rate_y4)
 

--- a/src/model/y4/y4_8_m12_treat.R
+++ b/src/model/y4/y4_8_m12_treat.R
@@ -6,6 +6,7 @@ y4_m12_treat_groups_list <- m12_treat_groups(input_df = y4_m12_FU_input_df,
                                              rebook_rate= m12_scan_rebook_rate_y4,
                                              diagnostic_rate = m12_diagnostic_rate_y4,
                                              incidental_rate = m12_incidental_rate_y4,
+                                             nodule_rate = m12_nodule_rate_y4,
                                              follow_up_rate = m12_m12_fu_rate_y4,
                                              cancer_rate = m12_cancer_rate_y4)
 

--- a/src/model/y5/y5_10_m24_treat.R
+++ b/src/model/y5/y5_10_m24_treat.R
@@ -6,6 +6,7 @@ y5_m24_treat_groups_list <- m24_treat_groups(input_df = y5_m24_FU_input_df,
                                              rebook_rate= m24_scan_rebook_rate_y5,
                                              diagnostic_rate = m24_diagnostic_rate_y5,
                                              incidental_rate = m24_incidental_rate_y5,
+                                             nodule_rate = m24_nodule_rate_y5,
                                              follow_up_rate = m24_m24_fu_rate_y5,
                                              cancer_rate = m24_cancer_rate_y5)
 

--- a/src/model/y5/y5_8_m12_treat.R
+++ b/src/model/y5/y5_8_m12_treat.R
@@ -6,6 +6,7 @@ y5_m12_treat_groups_list <- m12_treat_groups(input_df = y5_m12_FU_input_df,
                                              rebook_rate= m12_scan_rebook_rate_y5,
                                              diagnostic_rate = m12_diagnostic_rate_y5,
                                              incidental_rate = m12_incidental_rate_y5,
+                                             nodule_rate = m12_nodule_rate_y5,
                                              follow_up_rate = m12_m12_fu_rate_y5,
                                              cancer_rate = m12_cancer_rate_y5)
 

--- a/src/visualisation/y1_visuals.R
+++ b/src/visualisation/y1_visuals.R
@@ -181,7 +181,8 @@ y1_m12_treat_ct_act_hist <- m12_treat_ct_act_chart_visual(y1_m12_treat_ct_act_hi
 y1_m12_treat_pos_outcomes_hist_df <- y1_m12_treat_groups_list[[2]] %>%
   mutate(m12_treat_outcome_clean = case_when(m12_treat_outcome == "24M_FU" ~ "24 Month Follow-Up",
                                             m12_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                            m12_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                            m12_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                            m12_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y1_m12_treat_pos_outcomes_hist <- m12_treat_pos_outcomes_chart_visual(y1_m12_treat_pos_outcomes_hist_df, "#407EC9", "Year 1")
 
@@ -234,7 +235,8 @@ y1_m24_treat_ct_act_hist <- m24_treat_ct_act_chart_visual(y1_m24_treat_ct_act_hi
 y1_m24_treat_pos_outcomes_hist_df <- y1_m24_treat_groups_list[[2]] %>%
   mutate(m24_treat_outcome_clean = case_when(m24_treat_outcome == "48M_FU" ~ "48 Month Follow-Up",
                                              m24_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m24_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y1_m24_treat_pos_outcomes_hist <- m24_treat_pos_outcomes_chart_visual(y1_m24_treat_pos_outcomes_hist_df, "#407EC9", "Year 1")
 

--- a/src/visualisation/y2_visuals.R
+++ b/src/visualisation/y2_visuals.R
@@ -181,7 +181,8 @@ y2_m12_treat_ct_act_hist <- m12_treat_ct_act_chart_visual(y2_m12_treat_ct_act_hi
 y2_m12_treat_pos_outcomes_hist_df <- y2_m12_treat_groups_list[[2]] %>%
   mutate(m12_treat_outcome_clean = case_when(m12_treat_outcome == "24M_FU" ~ "24 Month Follow-Up",
                                              m12_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m12_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m12_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m12_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y2_m12_treat_pos_outcomes_hist <- m12_treat_pos_outcomes_chart_visual(y2_m12_treat_pos_outcomes_hist_df, "#407EC9", "Year 2")
 
@@ -234,7 +235,8 @@ y2_m24_treat_ct_act_hist <- m24_treat_ct_act_chart_visual(y2_m24_treat_ct_act_hi
 y2_m24_treat_pos_outcomes_hist_df <- y2_m24_treat_groups_list[[2]] %>%
   mutate(m24_treat_outcome_clean = case_when(m24_treat_outcome == "48M_FU" ~ "48 Month Follow-Up",
                                              m24_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m24_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y2_m24_treat_pos_outcomes_hist <- m24_treat_pos_outcomes_chart_visual(y2_m24_treat_pos_outcomes_hist_df, "#407EC9", "Year 2")
 

--- a/src/visualisation/y3_visuals.R
+++ b/src/visualisation/y3_visuals.R
@@ -181,7 +181,8 @@ y3_m12_treat_ct_act_hist <- m12_treat_ct_act_chart_visual(y3_m12_treat_ct_act_hi
 y3_m12_treat_pos_outcomes_hist_df <- y3_m12_treat_groups_list[[2]] %>%
   mutate(m12_treat_outcome_clean = case_when(m12_treat_outcome == "24M_FU" ~ "24 Month Follow-Up",
                                              m12_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m12_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m12_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m12_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y3_m12_treat_pos_outcomes_hist <- m12_treat_pos_outcomes_chart_visual(y3_m12_treat_pos_outcomes_hist_df, "#407EC9", "Year 3")
 
@@ -234,7 +235,8 @@ y3_m24_treat_ct_act_hist <- m24_treat_ct_act_chart_visual(y3_m24_treat_ct_act_hi
 y3_m24_treat_pos_outcomes_hist_df <- y3_m24_treat_groups_list[[2]] %>%
   mutate(m24_treat_outcome_clean = case_when(m24_treat_outcome == "48M_FU" ~ "48 Month Follow-Up",
                                              m24_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m24_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y3_m24_treat_pos_outcomes_hist <- m24_treat_pos_outcomes_chart_visual(y3_m24_treat_pos_outcomes_hist_df, "#407EC9", "Year 3")
 

--- a/src/visualisation/y4_visuals.R
+++ b/src/visualisation/y4_visuals.R
@@ -180,7 +180,8 @@ y4_m12_treat_ct_act_hist <- m12_treat_ct_act_chart_visual(y4_m12_treat_ct_act_hi
 y4_m12_treat_pos_outcomes_hist_df <- y4_m12_treat_groups_list[[2]] %>%
   mutate(m12_treat_outcome_clean = case_when(m12_treat_outcome == "24M_FU" ~ "24 Month Follow-Up",
                                              m12_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m12_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m12_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m12_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y4_m12_treat_pos_outcomes_hist <- m12_treat_pos_outcomes_chart_visual(y4_m12_treat_pos_outcomes_hist_df, "#407EC9", "Year 4")
 
@@ -233,7 +234,8 @@ y4_m24_treat_ct_act_hist <- m24_treat_ct_act_chart_visual(y4_m24_treat_ct_act_hi
 y4_m24_treat_pos_outcomes_hist_df <- y4_m24_treat_groups_list[[2]] %>%
   mutate(m24_treat_outcome_clean = case_when(m24_treat_outcome == "48M_FU" ~ "48 Month Follow-Up",
                                              m24_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m24_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y4_m24_treat_pos_outcomes_hist <- m24_treat_pos_outcomes_chart_visual(y4_m24_treat_pos_outcomes_hist_df, "#407EC9", "Year 4")
 

--- a/src/visualisation/y5_visuals.R
+++ b/src/visualisation/y5_visuals.R
@@ -181,7 +181,8 @@ y5_m12_treat_ct_act_hist <- m12_treat_ct_act_chart_visual(y5_m12_treat_ct_act_hi
 y5_m12_treat_pos_outcomes_hist_df <- y5_m12_treat_groups_list[[2]] %>%
   mutate(m12_treat_outcome_clean = case_when(m12_treat_outcome == "24M_FU" ~ "24 Month Follow-Up",
                                              m12_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m12_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m12_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m12_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y5_m12_treat_pos_outcomes_hist <- m12_treat_pos_outcomes_chart_visual(y5_m12_treat_pos_outcomes_hist_df, "#407EC9", "Year 5")
 
@@ -234,7 +235,8 @@ y5_m24_treat_ct_act_hist <- m24_treat_ct_act_chart_visual(y5_m24_treat_ct_act_hi
 y5_m24_treat_pos_outcomes_hist_df <- y5_m24_treat_groups_list[[2]] %>%
   mutate(m24_treat_outcome_clean = case_when(m24_treat_outcome == "48M_FU" ~ "48 Month Follow-Up",
                                              m24_treat_outcome == "Diagnostics" ~ "Additional Diagnostics",
-                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding"))
+                                             m24_treat_outcome == "Incidental" ~ "Incidental Finding",
+                                             m24_treat_outcome == "Nodule FU" ~ "Nodule Follow-Up"))
 
 y5_m24_treat_pos_outcomes_hist <- m24_treat_pos_outcomes_chart_visual(y5_m24_treat_pos_outcomes_hist_df, "#407EC9", "Year 5")
 


### PR DESCRIPTION
This PR will update the outputs to include the nodule follow-up outcome at the 12 month and 24 month scans.

This PR will address issue #27