### PR TITLE
Fix for m24 follow-up scans

### DIFF
--- a/src/model/y1/y1_8_m12_treat.R
+++ b/src/model/y1/y1_8_m12_treat.R
@@ -28,7 +28,7 @@ y1_m12_modalities_df <- m12_treatment_modalities(input_df = y1_m12_cancer_df,
 
 y1_m12_m24_FU_input_df <- y1_m12_treat_groups_list[[4]] 
 
-y1_m24_FU_input_df <- bind_rows(y1_m3_m24_FU_input_df, y1_m12_m24_FU_input_df)
+y1_m24_FU_input_df <- bind_rows(y1_ct_24M_FU_output, y1_m3_m24_FU_input_df, y1_m12_m24_FU_input_df)
 
 # Creating outputs to inform m24 reinvites
 

--- a/src/model/y2/y2_8_m12_treat.R
+++ b/src/model/y2/y2_8_m12_treat.R
@@ -28,7 +28,7 @@ y2_m12_modalities_df <- m12_treatment_modalities(input_df = y2_m12_cancer_df,
 
 y2_m12_m24_FU_input_df <- y2_m12_treat_groups_list[[4]] 
 
-y2_m24_FU_input_df <- bind_rows(y2_m3_m24_FU_input_df, y2_m12_m24_FU_input_df)
+y2_m24_FU_input_df <- bind_rows(y2_ct_24M_FU_output, y2_m3_m24_FU_input_df, y2_m12_m24_FU_input_df)
 
 # Creating outputs to inform m24 reinvites
 

--- a/src/model/y3/y3_8_m12_treat.R
+++ b/src/model/y3/y3_8_m12_treat.R
@@ -28,7 +28,7 @@ y3_m12_modalities_df <- m12_treatment_modalities(input_df = y3_m12_cancer_df,
 
 y3_m12_m24_FU_input_df <- y3_m12_treat_groups_list[[4]] 
 
-y3_m24_FU_input_df <- bind_rows(y3_m3_m24_FU_input_df, y3_m12_m24_FU_input_df)
+y3_m24_FU_input_df <- bind_rows(y3_ct_24M_FU_output, y3_m3_m24_FU_input_df, y3_m12_m24_FU_input_df)
 
 # Creating outputs to inform m24 reinvites
 

--- a/src/model/y4/y4_8_m12_treat.R
+++ b/src/model/y4/y4_8_m12_treat.R
@@ -28,7 +28,7 @@ y4_m12_modalities_df <- m12_treatment_modalities(input_df = y4_m12_cancer_df,
 
 y4_m12_m24_FU_input_df <- y4_m12_treat_groups_list[[4]] 
 
-y4_m24_FU_input_df <- bind_rows(y4_m3_m24_FU_input_df, y4_m12_m24_FU_input_df)
+y4_m24_FU_input_df <- bind_rows(y4_ct_24M_FU_output, y4_m3_m24_FU_input_df, y4_m12_m24_FU_input_df)
 
 # Creating outputs to inform m24 reinvites
 

--- a/src/model/y5/y5_8_m12_treat.R
+++ b/src/model/y5/y5_8_m12_treat.R
@@ -28,7 +28,7 @@ y5_m12_modalities_df <- m12_treatment_modalities(input_df = y5_m12_cancer_df,
 
 y5_m12_m24_FU_input_df <- y5_m12_treat_groups_list[[4]] 
 
-y5_m24_FU_input_df <- bind_rows(y5_m3_m24_FU_input_df, y5_m12_m24_FU_input_df)
+y5_m24_FU_input_df <- bind_rows(y5_ct_24M_FU_output, y5_m3_m24_FU_input_df, y5_m12_m24_FU_input_df)
 
 # Creating outputs to inform m24 reinvites
 


### PR DESCRIPTION
Fix for issue #28

Initial negative CT scans each year are added to the inputs for the Month 24 follow-up scans, previously missing.