### PR TITLE
Make population flows in and out relative to year 1

### DIFF
--- a/src/config/assumptions/assumptions_population.R
+++ b/src/config/assumptions/assumptions_population.R
@@ -39,3 +39,17 @@ age_out_y2 <- assumptions_pop[[6,5]]
 age_out_y3 <- assumptions_pop[[6,6]]
 age_out_y4 <- assumptions_pop[[6,7]]
 age_out_y5 <- assumptions_pop[[6,8]]
+
+# Age in and out relative -------------------------------------------------
+
+age_diff_y1 <- age_in_y1 - age_out_y1
+age_diff_y2 <- age_in_y2 - age_out_y2
+age_diff_y3 <- age_in_y3 - age_out_y3
+age_diff_y4 <- age_in_y4 - age_out_y4
+age_diff_y5 <- age_in_y5 - age_out_y5
+
+age_diff_y1_c <- age_diff_y1
+age_diff_y2_c <- (1 + age_diff_y1) * (1 + age_diff_y2)  - 1
+age_diff_y3_c <- (1 + age_diff_y2_c) * (1 + age_diff_y3)  - 1
+age_diff_y4_c <- (1 + age_diff_y3_c) * (1 + age_diff_y4)  - 1
+age_diff_y5_c <- (1 + age_diff_y4_c) * (1 + age_diff_y5)  - 1

--- a/src/model/functions/population.R
+++ b/src/model/functions/population.R
@@ -1,4 +1,4 @@
-uptake_pop <- function(start_pop, age_in, age_out, smk_current, smk_prev, screened_prev, repeats, uptake){
+uptake_pop <- function(start_pop, age_diff, smk_current, smk_prev, screened_prev, repeats, uptake){
   
   ### Simulate starting dataframes of the screening population
   screening_pop_df <- data.frame()
@@ -26,7 +26,7 @@ uptake_pop <- function(start_pop, age_in, age_out, smk_current, smk_prev, screen
     }
     
     ### Determine size of the population for screening in the year
-    screening_pop <- ((start_pop * (1 + (age_in - age_out)) * (smk_current + smk_prev)) * uptake) - screened_prev_value + repeats_value
+    screening_pop <- ((start_pop * (1 + (age_diff)) * (smk_current + smk_prev)) * uptake) - screened_prev_value + repeats_value
     
     screening_pop_trial <- data.frame(
       Trial = i,

--- a/src/model/y1/y1_1_pop.R
+++ b/src/model/y1/y1_1_pop.R
@@ -2,8 +2,7 @@
 # Simulate Year 1 Uptake Population ---------------------------------------
 
 y1_uptake_pop <- uptake_pop(start_pop = total_pop,
-                            age_in = age_in_y1,
-                            age_out = age_out_y1,
+                            age_diff =  age_diff_y1_c,
                             smk_current = smk_rate_current_y1,
                             smk_prev = smk_rate_prev_y1,
                             screened_prev = 0,

--- a/src/model/y2/y2_1_pop.R
+++ b/src/model/y2/y2_1_pop.R
@@ -2,8 +2,7 @@
 # Simulate Year 2 Uptake Population ---------------------------------------
 
 y2_uptake_pop <- uptake_pop(start_pop = total_pop,
-                            age_in = age_in_y2,
-                            age_out = age_out_y2,
+                            age_diff = age_diff_y2_c,
                             smk_current = smk_rate_current_y2,
                             smk_prev = smk_rate_prev_y2,
                             screened_prev = y2_screened_input_df,

--- a/src/model/y3/y3_1_pop.R
+++ b/src/model/y3/y3_1_pop.R
@@ -2,8 +2,7 @@
 # Simulate Year 3 Uptake Population ---------------------------------------
 
 y3_uptake_pop <- uptake_pop(start_pop = total_pop,
-                            age_in = age_in_y3,
-                            age_out = age_out_y3,
+                            age_diff = age_diff_y3_c,
                             smk_current = smk_rate_current_y3,
                             smk_prev = smk_rate_prev_y3,
                             screened_prev = y3_screened_input_df,

--- a/src/model/y4/y4_1_pop.R
+++ b/src/model/y4/y4_1_pop.R
@@ -2,8 +2,7 @@
 # Simulate Year 4 Uptake Population ---------------------------------------
 
 y4_uptake_pop <- uptake_pop(start_pop = total_pop,
-                            age_in = age_in_y4,
-                            age_out = age_out_y4,
+                            age_diff = age_diff_y4_c,
                             smk_current = smk_rate_current_y4,
                             smk_prev = smk_rate_prev_y4,
                             screened_prev = y4_screened_input_df,

--- a/src/model/y5/y5_1_pop.R
+++ b/src/model/y5/y5_1_pop.R
@@ -2,8 +2,7 @@
 # Simulate Year 5 Uptake Population ---------------------------------------
 
 y5_uptake_pop <- uptake_pop(start_pop = total_pop,
-                            age_in = age_in_y5,
-                            age_out = age_out_y5,
+                            age_diff = age_diff_y5_c,
                             smk_current = smk_rate_current_y5,
                             smk_prev = smk_rate_prev_y5,
                             screened_prev = y5_screened_input_df,


### PR DESCRIPTION
Ensure that the population flows in and out across each year are adjusted to be relative from year 1. More realistic to align with expectations of model input.

Fix for #35 