### PR TITLE
Making repeat invites cumulative in years 4 and 5

### DIFF
--- a/src/model/y4/y4_1_pop.R
+++ b/src/model/y4/y4_1_pop.R
@@ -6,7 +6,7 @@ y4_uptake_pop <- uptake_pop(start_pop = total_pop,
                             smk_current = smk_rate_current_y4,
                             smk_prev = smk_rate_prev_y4,
                             screened_prev = y4_screened_input_df,
-                            repeats = y4_reinvites,
+                            repeats = (y3_reinvites + y4_reinvites),
                             uptake = uptake_rate_y4)
 
 # Created previously screened dataframe -----------------------------------

--- a/src/model/y5/y5_1_pop.R
+++ b/src/model/y5/y5_1_pop.R
@@ -6,7 +6,7 @@ y5_uptake_pop <- uptake_pop(start_pop = total_pop,
                             smk_current = smk_rate_current_y5,
                             smk_prev = smk_rate_prev_y5,
                             screened_prev = y5_screened_input_df,
-                            repeats = y5_reinvites,
+                            repeats = (y3_reinvites + y4_reinvites + y5_reinvites),
                             uptake = uptake_rate_y5)
 
 # Create previously screened dataframe ------------------------------------


### PR DESCRIPTION
Ensuring that the reinvite numbers for years 4 and 5 are cumulative to offset cumulative previous patients screened inputs.

Fix for #30 