### PR TITLE
Amend reinvitation numbers to population function call to account for trials with 0 patients

### DIFF
--- a/src/model/y3/y3_1_pop.R
+++ b/src/model/y3/y3_1_pop.R
@@ -1,4 +1,15 @@
 
+# Update reinvites to account for any missing trials ----------------------
+
+y3_reinvites_update <-data.frame(
+                                  Trial = seq(trials),
+                                  Total = 0
+                                  ) %>%
+  left_join(y3_reinvites, by = c("Trial")) %>%
+  mutate(Total = coalesce(Total.y, Total.x)) %>%
+  select(c(1,4))
+
+
 # Simulate Year 3 Uptake Population ---------------------------------------
 
 y3_uptake_pop <- uptake_pop(start_pop = total_pop,
@@ -6,7 +17,7 @@ y3_uptake_pop <- uptake_pop(start_pop = total_pop,
                             smk_current = smk_rate_current_y3,
                             smk_prev = smk_rate_prev_y3,
                             screened_prev = y3_screened_input_df,
-                            repeats = y3_reinvites,
+                            repeats = y3_reinvites_update,
                             uptake = uptake_rate_y3)
 
 # Create previously screened dataframe ------------------------------------

--- a/src/model/y4/y4_1_pop.R
+++ b/src/model/y4/y4_1_pop.R
@@ -1,4 +1,18 @@
 
+# Update reinvites to account for any missing trials ----------------------
+
+y4_reinvites_update <-data.frame(
+                                  Trial = seq(trials),
+                                  Total = 0
+                                ) %>%
+  left_join(y4_reinvites, by = c("Trial")) %>%
+  mutate(Total = coalesce(Total.y, Total.x)) %>%
+  select(c(1,4))
+
+y4_reinvites_update_cumul <- union_all(y3_reinvites_update, y4_reinvites_update) %>%
+  group_by(Trial) %>%
+  summarise(Total = sum(Total, na.rm = TRUE))
+
 # Simulate Year 4 Uptake Population ---------------------------------------
 
 y4_uptake_pop <- uptake_pop(start_pop = total_pop,
@@ -6,7 +20,7 @@ y4_uptake_pop <- uptake_pop(start_pop = total_pop,
                             smk_current = smk_rate_current_y4,
                             smk_prev = smk_rate_prev_y4,
                             screened_prev = y4_screened_input_df,
-                            repeats = (y3_reinvites + y4_reinvites),
+                            repeats = y4_reinvites_update_cumul,
                             uptake = uptake_rate_y4)
 
 # Created previously screened dataframe -----------------------------------

--- a/src/model/y5/y5_1_pop.R
+++ b/src/model/y5/y5_1_pop.R
@@ -1,4 +1,19 @@
 
+# Update reinvites to account for any missing trials ----------------------
+
+y5_reinvites_update <-data.frame(
+                                  Trial = seq(trials),
+                                  Total = 0
+                                ) %>%
+  left_join(y5_reinvites, by = c("Trial")) %>%
+  mutate(Total = coalesce(Total.y, Total.x)) %>%
+  select(c(1,4))
+
+y5_reinvites_update_cumul <- union_all(y4_reinvites_update_cumul, y5_reinvites_update) %>%
+  group_by(Trial) %>%
+  summarise(Total = sum(Total, na.rm = TRUE))
+
+
 # Simulate Year 5 Uptake Population ---------------------------------------
 
 y5_uptake_pop <- uptake_pop(start_pop = total_pop,
@@ -6,7 +21,7 @@ y5_uptake_pop <- uptake_pop(start_pop = total_pop,
                             smk_current = smk_rate_current_y5,
                             smk_prev = smk_rate_prev_y5,
                             screened_prev = y5_screened_input_df,
-                            repeats = (y3_reinvites + y4_reinvites + y5_reinvites),
+                            repeats = y5_reinvites_update_cumul,
                             uptake = uptake_rate_y5)
 
 # Create previously screened dataframe ------------------------------------


### PR DESCRIPTION
Amendment to create a dataframe that contains rows for each trial with a value of 0 re-invites where necessary.

Fix for #40 